### PR TITLE
Switch to Maya 2022-2023

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -5,6 +5,10 @@
 
 Official implementation of [Generating Datasets of 3D Garments with Sewing Patterns](https://arxiv.org/abs/2109.05633) (accepted to NeurIPS 2021 Dataset and Benchmarks Track).
 
+## News!
+
+* Nov. 21, 2022: switched to using Maya 2022+. Support for earlier versions is removed
+
 ## Dataset
 
 Using this data generator, we created a [Dataset of 3D Garments with Sewing patterns](https://doi.org/10.5281/zenodo.5267549) consisting of 19 garment types and more then 20 000 garment samples. 

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -7,7 +7,7 @@ Official implementation of [Generating Datasets of 3D Garments with Sewing Patte
 
 ## News!
 
-* Nov. 21, 2022: switched to using Maya 2022+. Support for earlier versions is removed
+* Nov. 21, 2022: switched to using Maya 2022+. NOTE: Support for earlier versions is removed. Use the state before the last merge to use the generator with Maya below 2022
 
 ## Dataset
 

--- a/data_generation/datascan.py
+++ b/data_generation/datascan.py
@@ -9,10 +9,10 @@
         d:/Autodesk/Maya2020/bin/mayapy.exe "./data_generation/datascan.py"
     """
 
-from __future__ import print_function
 import os
 import time
 from datetime import timedelta
+from importlib import reload
 
 # Maya
 from maya import cmds
@@ -121,7 +121,7 @@ if __name__ == "__main__":
         # go over the examples in the data
         start_time = time.time()
         to_ignore = ['renders']  # special dirs not to include in the pattern list
-        root, dirs, files = next(os.walk(datapath))  # cannot use os.scandir in python 2.7
+        root, dirs, files = next(os.walk(datapath))  
 
         for name in dirs:
             if name not in to_ignore:

--- a/data_generation/datasim.py
+++ b/data_generation/datasim.py
@@ -1,6 +1,6 @@
 """
     Run or Resume simulation of a pattern dataset with MayaPy standalone mode
-    Note that this module is executed in Maya (or by mayapy) and is Python 2.7 friendly.
+    Note that this module is executed in Maya (or by mayapy)
 
     How to use: 
         * fill out system.json with approppriate paths 
@@ -8,11 +8,10 @@
         <path_to_maya/bin>/mayapy.exe ./datasim.py --data <dataset folder name> --minibatch <size>  --config <simulation_rendering_configuration.json>
 
 """
-from __future__ import print_function
 import argparse
 import os
-import errno
 import sys
+from importlib import reload
 
 from maya import cmds
 import maya.standalone 	

--- a/data_generation/datasim_runner.sh
+++ b/data_generation/datasim_runner.sh
@@ -22,7 +22,7 @@ trap 'sigint'  INT
 # -- Main calls --
 num_samples=30   # number of reloads and re-sim vs. speed to detect Maya\Qualoth hang
 per_sample_delay=$((7*60))  # give about 7 min per sample before detecting Maya to hang
-dataset=data_5_pants_straight_sides_210810-21-39-14
+dataset=data_5_pants_straight_sides_221122-19-44-29
 config=T_body_green_intersect_tolerance.json
 ret_code=1
 STARTTIME=$(date +%s)
@@ -31,7 +31,7 @@ do
     # https://unix.stackexchange.com/questions/405337/bash-if-command-doesnt-finish-in-x-time
     # set timeout to catch hangs && forse kill if not soft terminating
     # NOTE: update the location of mayapy.exe HERE!
-    timeout -k 30 $((num_samples * per_sample_delay)) /d/Autodesk/Maya2020/bin/mayapy.exe "./datasim.py" --data $dataset --minibatch $num_samples  --config $config
+    timeout -k 30 $((num_samples * per_sample_delay)) /c/Program\ Files/Autodesk/Maya2023/bin/mayapy.exe "./datasim.py" --data $dataset --minibatch $num_samples  --config $config
     ret_code=$?
     echo $ret_code   # if it's 124, the execution was finished by timeout
 

--- a/data_generation/garmentviewer.py
+++ b/data_generation/garmentviewer.py
@@ -1,11 +1,11 @@
 """
     Loads maya interface for editing & testing template files
-    Python 2.7 compatible
-    * Maya 2018+
+    * Maya 2022+
     * Qualoth
 """
 
 from maya import cmds
+from importlib import reload
 
 # My modules
 import mayaqltools as mymaya

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -9,8 +9,9 @@
 * [Qualoth 2020](https://www.qualoth.com/) cloth simulator 
 
 ### Maya Python API Environment
-* Numpy (for Python 2.7)
-    * The process for installation is desribed in guides like [this one](https://forums.autodesk.com/t5/maya-programming/guide-how-to-install-numpy-scipy-in-maya-windows-64-bit/td-p/5796722)
+* Numpy
+* Scipy
+    [Installation instructions for python packages for Maya](https://knowledge.autodesk.com/support/maya/learn-explore/caas/CloudHelp/cloudhelp/2022/ENU/Maya-Scripting/files/GUID-72A245EC-CDB4-46AB-BEE0-4BBBF9791627-htm.html)
 
 ### Generic Python Environment
 * Python 3.6+
@@ -26,7 +27,6 @@
 
 <details>
     <summary> <b>NOTE: Lib verstions used in development</b></summary>
-
     python==3.8.5
     numpy==1.19.2
     scipy==1.6.2

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -6,14 +6,12 @@
     * Qualoth version for Maya 2022 is not available at the moment of the main development
 
     >☝ Arnold requires license to render simulated data without watermarks.
-* [Qualoth 2020](https://www.qualoth.com/) cloth simulator 
+* [Qualoth 2020](https://www.qualoth.com/) cloth simulator   
 
-### Maya Python API Environment
-* Numpy
-* Scipy
-    [Installation instructions for python packages for Maya](https://knowledge.autodesk.com/support/maya/learn-explore/caas/CloudHelp/cloudhelp/2022/ENU/Maya-Scripting/files/GUID-72A245EC-CDB4-46AB-BEE0-4BBBF9791627-htm.html)
+### Python Environment (both in Maya Python Environment, and for usual development)
 
-### Generic Python Environment
+[Installation instructions for python packages for Maya](https://knowledge.autodesk.com/support/maya/learn-explore/caas/CloudHelp/cloudhelp/2022/ENU/Maya-Scripting/files/GUID-72A245EC-CDB4-46AB-BEE0-4BBBF9791627-htm.html)
+
 * Python 3.6+
 * numpy
 * scipy
@@ -21,6 +19,7 @@
 * [svgwrite](https://pypi.org/project/svgwrite/)
 * psutil
 * wmi
+    * May require pypiwin32
     * [Troubleshooting 'DLL load failed while importing win32api'](https://stackoverflow.com/questions/58612306/how-to-fix-importerror-dll-load-failed-while-importing-win32api) error on Win
 
 

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -2,17 +2,14 @@
 
 ## Dependencies
 
-* Autodesk Maya 2018/2020 with Arnold
-    * Qualoth version for Maya 2022 is not available at the moment of the main development
-
+* Autodesk Maya 2022+ with Arnold
     >☝ Arnold requires license to render simulated data without watermarks.
-* [Qualoth 2020](https://www.qualoth.com/) cloth simulator   
 
+* [Qualoth](http://www.fxgear.net/vfx-software?locale=en), versiton 4.7.7+ (with Maya 2022 support)
 ### Python Environment (both in Maya Python Environment, and for usual development)
 
 [Installation instructions for python packages for Maya](https://knowledge.autodesk.com/support/maya/learn-explore/caas/CloudHelp/cloudhelp/2022/ENU/Maya-Scripting/files/GUID-72A245EC-CDB4-46AB-BEE0-4BBBF9791627-htm.html)
 
-* Python 3.6+
 * numpy
 * scipy
 * [svglib](https://pypi.org/project/svglib/)
@@ -23,9 +20,8 @@
     * [Troubleshooting 'DLL load failed while importing win32api'](https://stackoverflow.com/questions/58612306/how-to-fix-importerror-dll-load-failed-while-importing-win32api) error on Win
 
 
-
 <details>
-    <summary> <b>NOTE: Lib verstions used in development</b></summary>
+    <summary> <b>NOTE: Lib versions used in development</b></summary>
     python==3.8.5
     numpy==1.19.2
     scipy==1.6.2

--- a/packages/customconfig.py
+++ b/packages/customconfig.py
@@ -1,6 +1,5 @@
 """
     The module contain Porperties class to manage paramters & stats in various parts of the system
-    The module might be used in Maya, so its Python 2.7 compatible
 """
 
 from datetime import timedelta
@@ -10,12 +9,10 @@ import traceback
 import sys
 
 # for system info
-if sys.version_info.major >= 3:  # prevent from loading within Maya -- Py2.7 compatibility
-    import platform
-    import json
-    import psutil
-    if 'win' in platform.system() or 'Win' in platform.system():
-        import wmi  # pip install wmi
+import platform
+import psutil
+if 'win' in platform.system() or 'Win' in platform.system():
+    import wmi  # pip install wmi
 
 
 class Properties():

--- a/packages/mayaqltools/__init__.py
+++ b/packages/mayaqltools/__init__.py
@@ -1,24 +1,25 @@
 """
-    Package for to simulate garments from patterns in Maya with Qualoth
-    Note that Maya uses Python 2.7 (incl Maya 2020) hence this package is adapted to Python 2.7
+    Package for to simulate garments from patterns in Maya with Qualoth. 
 
     Main dependencies:
-        * Maya 2018+
+        * Maya 2022+ (uses Python 3.6+)
         * Arnold Renderer
         * Qualoth (compatible with your Maya version)
     
     To run the package in Maya don't foget to add it to PYTHONPATH!
 """
-import mayascene
+from importlib import reload
+
+import mayaqltools.mayascene as mayascene
 reload(mayascene)
 
 from .mayascene import PatternLoadingError, MayaGarment, Scene, MayaGarmentWithUI
 
-import simulation
-import qualothwrapper
-import garmentUI
-import scan_imitation
-import utils
+import mayaqltools.simulation as simulation
+import mayaqltools.qualothwrapper as qualothwrapper
+import mayaqltools.garmentUI as garmentUI
+import mayaqltools.scan_imitation as scan_imitation
+import mayaqltools.utils as utils
 
 reload(simulation)
 reload(qualothwrapper)

--- a/packages/mayaqltools/garmentUI.py
+++ b/packages/mayaqltools/garmentUI.py
@@ -143,6 +143,7 @@ class State(object):
     def serialize(self, directory):
         """Serialize text-like objects"""
         self.config.serialize(os.path.join(directory, 'sim_props.json'))
+        self.garment.view_ids = True
         self.garment.serialize(directory, to_subfolder=False)
 
     def save_scene(self, directory):

--- a/packages/mayaqltools/garmentUI.py
+++ b/packages/mayaqltools/garmentUI.py
@@ -1,13 +1,10 @@
 """
     Maya interface for editing & testing patterns files
-    Python 2.7 compatible
-    * Maya 2018+
+    * Maya 2022+
     * Qualoth
 """
 
 # Basic
-from __future__ import print_function
-from __future__ import division
 from functools import partial
 from datetime import datetime
 import os

--- a/packages/mayaqltools/mayascene.py
+++ b/packages/mayaqltools/mayascene.py
@@ -20,10 +20,10 @@ from mtoa.cmds.arnoldRender import arnoldRender
 import mtoa.core
 
 # My modules
-import pattern.core as core
+import pattern.wrappers as wrappers
 from mayaqltools import qualothwrapper as qw
 from mayaqltools import utils
-reload(core)
+reload(wrappers)
 reload(qw)
 reload(utils)
 
@@ -31,7 +31,7 @@ class PatternLoadingError(BaseException):
     """To be rised when a pattern cannot be loaded correctly to 3D"""
     pass
 
-class MayaGarment(core.ParametrizedPattern):
+class MayaGarment(wrappers.VisPattern):
     """
     Extends a pattern specification in custom JSON format to work with Maya
         Input:

--- a/packages/mayaqltools/mayascene.py
+++ b/packages/mayaqltools/mayascene.py
@@ -1210,6 +1210,9 @@ class Scene(object):
         # https://forums.autodesk.com/t5/maya-programming/rendering-with-arnold-in-a-python-script/td-p/7710875
         # NOTE that attribute names depend on Maya version. These are for Maya2018-Maya2020
         im_size = self.config['resolution']
+        
+        # image setup
+        old_setup = self._set_image_size(im_size, im_size[0]/im_size[1], im_size[0]/im_size[1])
         cmds.setAttr("defaultArnoldDriver.aiTranslator", "png", type="string")
 
         # fixing dark rendering problem
@@ -1217,6 +1220,7 @@ class Scene(object):
         cmds.colorManagementPrefs(e=True, outputTransformEnabled=True, outputUseViewTransform=True)
 
         # render all the cameras
+        curr_frame = cmds.currentTime(query=True)
         start_time = time.time()
         for camera in self.cameras:
             print('Rendering from camera {}'.format(camera))
@@ -1226,8 +1230,9 @@ class Scene(object):
             filename = os.path.join(save_to, local_name)
             cmds.setAttr("defaultArnoldDriver.prefix", filename, type="string")
 
-            arnoldRender(im_size[0], im_size[1], True, True, camera, ' -layer defaultRenderLayer')
-            
+            cmds.arnoldRender(width=im_size[0], height=im_size[1], batch=True, frameSequence=curr_frame, camera=camera)
+        
+        self._set_image_size(*old_setup)  # restore settings    
         self.stats['render_time'][name] = time.time() - start_time
 
     def fetch_props_from_Maya(self):
@@ -1381,3 +1386,22 @@ class Scene(object):
         shader_group = cmds.sets(renderable=True, noSurfaceShader=True, empty=True, name=name)
         cmds.connectAttr(material + '.outColor', shader_group + '.surfaceShader')
         return shader_group
+
+    def _set_image_size(self, im_size, ar_pix, ar_device):
+        """Set image size for rendering"""
+
+        # remember the old settings to allow restoration
+        old_ar_pix = cmds.getAttr("defaultResolution.pixelAspect")
+        old_ar_device = cmds.getAttr("defaultResolution.deviceAspectRatio")
+
+        old_size = [0, 0]
+        old_size[0] = cmds.getAttr("defaultResolution.width")
+        old_size[1] = cmds.getAttr("defaultResolution.height")
+
+        cmds.setAttr("defaultResolution.width", im_size[0])
+        cmds.setAttr("defaultResolution.height", im_size[1])
+        cmds.setAttr("defaultResolution.pixelAspect", ar_pix)
+        cmds.setAttr("defaultResolution.deviceAspectRatio", ar_device)
+
+        return old_size, old_ar_pix, old_ar_device
+

--- a/packages/mayaqltools/mayascene.py
+++ b/packages/mayaqltools/mayascene.py
@@ -1,16 +1,14 @@
 """
     Module contains classes needed to simulate garments from patterns in Maya.
-    Note that Maya uses Python 2.7 (incl Maya 2020) hence this module is adapted to Python 2.7
 """
 # Basic
-from __future__ import print_function
-from __future__ import division
 from functools import partial
 import copy
 import errno
 import numpy as np
 import os
 import time
+from importlib import reload
 
 # Maya
 from maya import cmds

--- a/packages/mayaqltools/qualothwrapper.py
+++ b/packages/mayaqltools/qualothwrapper.py
@@ -2,13 +2,10 @@
     Qualoth scripts are written in MEL. 
     This module makes a python interface to them
     Notes:
-        * this module is Python 2.7-friendly
         * Error checks are sparse to save coding time & lines. 
             This sould not be a problem during the normal workflow
     
 """
-from __future__ import print_function
-from __future__ import division
 import time
 import sys
 

--- a/packages/mayaqltools/scan_imitation.py
+++ b/packages/mayaqltools/scan_imitation.py
@@ -1,11 +1,9 @@
 """
     Maya script for removing faces from 3D garement model that are not visible from the outside cameras
     The goal is to imitate scanning artifacts that result in missing geometry
-    Python 2.7 compatible
-    * Maya 2018+
+    * Maya 2022+
 """
 
-from __future__ import print_function
 from maya import OpenMaya
 from maya import cmds
 import numpy as np
@@ -97,7 +95,7 @@ def remove_invisible(target, obstacles=[], num_rays=30, visibile_rays=4):
                     and not any([utils.test_ray_intersect(mesh, face_mean, rayDir, acc,) for mesh, acc in zip(obstacles_meshes, obstacles_accs)])  # intesects any of the obstacles
                     and not utils.test_ray_intersect(target_mesh, face_mean, rayDir, target_accelerator, hit_tol=1e-5)):  # intersects itself
                 visible_count += 1
-                if visible_count >= visibile_rays:  # enough rays are visible -- no need to test more; Python 2.7 division
+                if visible_count >= visibile_rays:  # enough rays are visible -- no need to test more
                     visible = True
 
         if not visible:
@@ -122,6 +120,7 @@ if __name__ == "__main__":
     # Copy the following block to Maya script editor and modify to 
     import maya.cmds as cmds
     import mayaqltools as mymaya
+    from importlib import reload
     reload(mymaya)
 
     body = cmds.ls('*f_smpl*:Mesh')[0]

--- a/packages/mayaqltools/simulation.py
+++ b/packages/mayaqltools/simulation.py
@@ -1,7 +1,6 @@
 """Routines to run cloth simulation in Maya + Qualoth"""
 
 # Basic
-from __future__ import print_function
 import time
 import os
 
@@ -250,7 +249,6 @@ def _get_pattern_files(data_path, dataset_props):
     root, dirs, files = next(os.walk(data_path))
     if dataset_props['to_subfolders']:
         # https://stackoverflow.com/questions/800197/how-to-get-all-of-the-immediate-subdirectories-in-python
-        # cannot use os.scandir in python 2.7
         for directory in dirs:
             if directory not in to_ignore:
                 pattern_specs.append(os.path.join(root, directory, 'specification.json'))  # cereful for file name changes ^^

--- a/packages/pattern/core.py
+++ b/packages/pattern/core.py
@@ -1,10 +1,7 @@
 """
     Module for basic operations on patterns
-    The code is compatible with both Python 2.7 (to be used in Maya 2020) and higher versions
 """
 # Basic
-from __future__ import print_function
-from __future__ import division
 import copy
 from datetime import datetime
 import errno
@@ -12,9 +9,6 @@ import json
 import numpy as np
 import os
 import random
-import sys
-if sys.version_info[0] >= 3:
-    from scipy.spatial.transform import Rotation as scipy_rot  # Not available in scipy 0.19.1 installed for Maya
 
 # My
 from pattern import rotation as rotation_tools
@@ -230,7 +224,7 @@ class BasicPattern(object):
             [top_right[0], mid_y],
             [low_left[0], mid_y]
         ]
-        rot_matrix = rotation_tools.euler_xyz_to_R(panel['rotation'])  # calculate once for all points # Maya (Python 2.7) compatible
+        rot_matrix = rotation_tools.euler_xyz_to_R(panel['rotation'])  # calculate once for all points 
         mid_points_3D = np.vstack(tuple(
             [self._point_in_3D(coords, rot_matrix, panel['translation']) for coords in mid_points_2D]
         ))

--- a/packages/pattern/rotation.py
+++ b/packages/pattern/rotation.py
@@ -1,5 +1,6 @@
 """
     Simple Rotation Conversion routines (Maya-Python2.7-Compatible!!)
+    TODO: Can be substituted with scipy rotation transformation routines for Maya2022+
 """
 import numpy as np
 import math as m

--- a/packages/pattern/wrappers.py
+++ b/packages/pattern/wrappers.py
@@ -1,5 +1,5 @@
 """
-    To be used in Python 3.6+ due to dependencies (failed to install reportlab for Python 2.7 used by Maya)
+    To be used in Python 3.6+ due to dependencies
 """
 import copy
 import random

--- a/packages/pattern/wrappers.py
+++ b/packages/pattern/wrappers.py
@@ -94,8 +94,9 @@ class VisPattern(core.ParametrizedPattern):
         """
             To get to image coordinates one might need to flip Y axis
         """
-        point[1] *= -1
-        return point
+        flipped_point = list(point)  # top-level copy
+        flipped_point[1] *= -1
+        return flipped_point
 
     def _draw_a_panel(self, drawing, panel_name, offset=[0, 0]):
         """

--- a/utility scripts/all_data_has_all_files.py
+++ b/utility scripts/all_data_has_all_files.py
@@ -64,7 +64,7 @@ for dataset in dataset_folders:
 
     # ----- Missing files ---------
     to_ignore = ['renders']  # special dirs not to include in the pattern list
-    root, dirs, files = next(os.walk(datapath))  # cannot use os.scandir in python 2.7
+    root, dirs, files = next(os.walk(datapath)) 
 
     # per element checks
     elem_count = 0
@@ -113,7 +113,7 @@ for dataset in dataset_folders:
     # -------- Renders folder check (if present at all) -----------
     if any('renders' in name for name in dirs):
         render_folders_exist.append('{}::Info::Render folder exists'.format(dataset))
-        root, dirs, files = next(os.walk(os.path.join(datapath, 'renders')))  # cannot use os.scandir in python 2.7
+        root, dirs, files = next(os.walk(os.path.join(datapath, 'renders'))) 
         num_renders = len(files)
         expected_min_num = data_size * 2 - num_fails
         if num_renders != data_size * 2:


### PR DESCRIPTION
Porting the code to support Maya 2022-2023. The main advantage of newer versions of Maya is switch to Python 3 from deprecated 2.7. Yay!